### PR TITLE
Added the option to announce on chat the song that is now playing.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,14 +11,14 @@ maven_group = me.john200410
 
 # use java 17 for minecraft versions 1.20.4 and older
 # use java 21 for minecraft versions 1.20.5 and newer
-java_version = 17
+java_version = 21
 
 # minecraft version to compile with
 # other supported versions of the game can be added in rusherhack-plugin.json
-minecraft_version = 1.20.4
+minecraft_version = 1.21.4
 
 # parchment mappings
-parchment_version = 1.20.1:2023.09.03
+parchment_version = 1.21.4:2025.03.23
 
 # fabric loader version
 fabric_loader_version = 0.16.9

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,14 +11,14 @@ maven_group = me.john200410
 
 # use java 17 for minecraft versions 1.20.4 and older
 # use java 21 for minecraft versions 1.20.5 and newer
-java_version = 21
+java_version = 17
 
 # minecraft version to compile with
 # other supported versions of the game can be added in rusherhack-plugin.json
-minecraft_version = 1.21.4
+minecraft_version = 1.20.4
 
 # parchment mappings
-parchment_version = 1.21.4:2025.03.23
+parchment_version = 1.20.1:2023.09.03
 
 # fabric loader version
 fabric_loader_version = 0.16.9

--- a/src/main/java/me/john200410/spotify/ui/SpotifyHudElement.java
+++ b/src/main/java/me/john200410/spotify/ui/SpotifyHudElement.java
@@ -83,6 +83,7 @@ public class SpotifyHudElement extends ResizeableHudElement {
 	private final ColorSetting backgroundColor = new ColorSetting("Color", new Color(BACKGROUND_COLOR, true));
 	private final NumberSetting<Double> updateDelay = new NumberSetting<>("UpdateDelay", 0.5d, 0.25d, 2d);
     private final BooleanSetting messageChat = new BooleanSetting("Chat Announcement", false);
+    private final BooleanSetting messageChatClientSide = new BooleanSetting("Client-Side", true);
 	
 	private final BooleanSetting binds = new BooleanSetting("Binds", false);
 	private final BindSetting playPauseBind = new BindSetting("Play/Pause", NullKey.INSTANCE);
@@ -132,6 +133,8 @@ public class SpotifyHudElement extends ResizeableHudElement {
 				this.authenticateButton.setValue(true);
 			}
 		});
+
+        this.messageChat.addSubSettings(messageChatClientSide);
 
 		this.background.addSubSettings(backgroundColor);
 		this.binds.addSubSettings(playPauseBind, backBind, nextBind, back5Bind, next5Bind);
@@ -543,9 +546,13 @@ public class SpotifyHudElement extends ResizeableHudElement {
 			this.artists.setText("by " + Strings.join(artists, ", "));
 			this.album.setText("on " + song.album.name);
             if (messageChat.getValue() == true) {
-                mc.player.connection.sendChat(">Now playing " + song.name + " " + this.artists.text + " " + this.album.text);
+                if (messageChatClientSide.getValue() == true) {
+                    ChatUtils.print("Now playing " + song.name + " " + this.artists.text + " " + this.album.text + ".");
+                } else {
+                    mc.player.connection.sendChat(">Now playing " + song.name + " " + this.artists.text + " " + this.album.text + ".");
+                }
             }
-		}
+        }
 		
 		static class ScrollingText {
 			

--- a/src/main/java/me/john200410/spotify/ui/SpotifyHudElement.java
+++ b/src/main/java/me/john200410/spotify/ui/SpotifyHudElement.java
@@ -1,6 +1,5 @@
 package me.john200410.spotify.ui;
 
-import net.minecraft.client.multiplayer.ClientPacketListener;
 import com.mojang.blaze3d.platform.NativeImage;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;

--- a/src/main/java/me/john200410/spotify/ui/SpotifyHudElement.java
+++ b/src/main/java/me/john200410/spotify/ui/SpotifyHudElement.java
@@ -1,5 +1,6 @@
 package me.john200410.spotify.ui;
 
+import net.minecraft.client.multiplayer.ClientPacketListener;
 import com.mojang.blaze3d.platform.NativeImage;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
@@ -81,6 +82,7 @@ public class SpotifyHudElement extends ResizeableHudElement {
 	private final BooleanSetting background = new BooleanSetting("Background", true);
 	private final ColorSetting backgroundColor = new ColorSetting("Color", new Color(BACKGROUND_COLOR, true));
 	private final NumberSetting<Double> updateDelay = new NumberSetting<>("UpdateDelay", 0.5d, 0.25d, 2d);
+    private final BooleanSetting messageChat = new BooleanSetting("Chat Announcement", false);
 	
 	private final BooleanSetting binds = new BooleanSetting("Binds", false);
 	private final BindSetting playPauseBind = new BindSetting("Play/Pause", NullKey.INSTANCE);
@@ -130,11 +132,17 @@ public class SpotifyHudElement extends ResizeableHudElement {
 				this.authenticateButton.setValue(true);
 			}
 		});
+
+        this.messageChat.onChange((c) -> {
+
+        });
+
+
 		
 		this.background.addSubSettings(backgroundColor);
 		this.binds.addSubSettings(playPauseBind, backBind, nextBind, back5Bind, next5Bind);
 		
-		this.registerSettings(authenticateButton, background, updateDelay, binds);
+		this.registerSettings(authenticateButton, messageChat,background, updateDelay, binds);
 		
 		//dont ask
 		//this.setupDummyModuleBecauseImFuckingStupidAndForgotToRegisterHudElementsIntoTheEventBus();
@@ -540,6 +548,9 @@ public class SpotifyHudElement extends ResizeableHudElement {
 			
 			this.artists.setText("by " + Strings.join(artists, ", "));
 			this.album.setText("on " + song.album.name);
+            if (messageChat.getValue() == true) {
+                mc.player.connection.sendChat(">Now playing " + song.name + " " + this.artists.text + " " + this.album.text);
+            }
 		}
 		
 		static class ScrollingText {

--- a/src/main/java/me/john200410/spotify/ui/SpotifyHudElement.java
+++ b/src/main/java/me/john200410/spotify/ui/SpotifyHudElement.java
@@ -133,12 +133,6 @@ public class SpotifyHudElement extends ResizeableHudElement {
 			}
 		});
 
-        this.messageChat.onChange((c) -> {
-
-        });
-
-
-		
 		this.background.addSubSettings(backgroundColor);
 		this.binds.addSubSettings(playPauseBind, backBind, nextBind, back5Bind, next5Bind);
 		


### PR DESCRIPTION
Added a boolean option to the HUD that, when enabled, announces the currently playing song in chat, including the artist and album name, using green text.
The current format is ">Now playing [song name] by [artist(s)] on [album]".

Useful for players who want to share the currently playing song in global chat.
Future improvements could include displaying it client-side as a sub-setting and allowing users to customize the chat message format.

<img width="577" height="40" alt="example" src="https://github.com/user-attachments/assets/c5588dc4-c763-460c-a53a-68b2aacd2461" />
